### PR TITLE
feat: Add configurable headers

### DIFF
--- a/dist/Defaults.d.ts
+++ b/dist/Defaults.d.ts
@@ -2,10 +2,12 @@ declare const _default: {
     JWT_ENDPOINT: string;
     JWT_ROUTE_VALIDATE: string;
     JWT_ROUTE_GENERATE: string;
+    HEADERS: {};
 };
 export default _default;
 export interface OPTIONS {
     JWT_ENDPOINT: string;
     JWT_ROUTE_VALIDATE: string;
     JWT_ROUTE_GENERATE: string;
+    HEADERS: Object;
 }

--- a/dist/Defaults.js
+++ b/dist/Defaults.js
@@ -4,5 +4,6 @@ exports.default = {
     JWT_ENDPOINT: '/wp-json/jwt-auth/v1',
     JWT_ROUTE_VALIDATE: '/validate',
     JWT_ROUTE_GENERATE: '/token',
+    HEADERS: {},
 };
 //# sourceMappingURL=Defaults.js.map

--- a/dist/Index.js
+++ b/dist/Index.js
@@ -1,4 +1,12 @@
 "use strict";
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
@@ -55,7 +63,9 @@ exports.generateToken = function (host, username, password) { return __awaiter(_
         switch (_a.label) {
             case 0:
                 generateTokenEndpoint = host + "/" + CONFIG.JWT_ENDPOINT + "/" + CONFIG.JWT_ROUTE_GENERATE;
-                return [4 /*yield*/, axios_1.default.post(generateTokenEndpoint, { username: username, password: password })];
+                return [4 /*yield*/, axios_1.default.post(generateTokenEndpoint, { username: username, password: password }, {
+                        headers: __assign({}, CONFIG.HEADERS),
+                    })];
             case 1:
                 response = _a.sent();
                 switch (response.status) {
@@ -73,13 +83,13 @@ exports.generateToken = function (host, username, password) { return __awaiter(_
  * @returns true if token is successfully validated
  */
 exports.validateToken = function (host, token) { return __awaiter(_this, void 0, void 0, function () {
-    var validateTokenEndpoint, authHeader, response;
+    var validateTokenEndpoint, headers, response;
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
                 validateTokenEndpoint = host + "/" + CONFIG.JWT_ENDPOINT + "/" + CONFIG.JWT_ROUTE_VALIDATE;
-                authHeader = { headers: { Authorization: 'bearer ' + token } };
-                return [4 /*yield*/, axios_1.default.post(validateTokenEndpoint, {}, authHeader)];
+                headers = { headers: __assign({ Authorization: 'Bearer ' + token }, CONFIG.HEADERS) };
+                return [4 /*yield*/, axios_1.default.post(validateTokenEndpoint, {}, headers)];
             case 1:
                 response = _a.sent();
                 if (response.status === 200) {
@@ -100,7 +110,9 @@ exports.connectToJwt = function (host) { return __awaiter(_this, void 0, void 0,
         switch (_a.label) {
             case 0:
                 generateTokenEndpoint = host + "/" + CONFIG.JWT_ENDPOINT + "/" + CONFIG.JWT_ROUTE_GENERATE;
-                return [4 /*yield*/, axios_1.default.post(generateTokenEndpoint)];
+                return [4 /*yield*/, axios_1.default.post(generateTokenEndpoint, {}, {
+                        headers: __assign({}, CONFIG.HEADERS),
+                    })];
             case 1:
                 response = _a.sent();
                 if (response.status === 404) {

--- a/lib/Defaults.ts
+++ b/lib/Defaults.ts
@@ -2,10 +2,12 @@ export default {
     JWT_ENDPOINT: '/wp-json/jwt-auth/v1',
     JWT_ROUTE_VALIDATE: '/validate',
     JWT_ROUTE_GENERATE: '/token',
+    HEADERS: {},
 };
 
 export interface OPTIONS {
     JWT_ENDPOINT: string;
     JWT_ROUTE_VALIDATE: string;
     JWT_ROUTE_GENERATE: string;
+    HEADERS: Object;
 }

--- a/lib/Index.ts
+++ b/lib/Index.ts
@@ -41,7 +41,11 @@ export const configure = (options: OPTIONS): void => {
  */
 export const generateToken = async (host: string, username: string, password: string): Promise<JWT> => {
     const generateTokenEndpoint = `${host}/${CONFIG.JWT_ENDPOINT}/${CONFIG.JWT_ROUTE_GENERATE}`;
-    const response = await axios.post(generateTokenEndpoint, { username, password });
+    const response = await axios.post(generateTokenEndpoint, { username, password }, {
+        headers: {
+            ...CONFIG.HEADERS,
+        },
+    });
     switch (response.status) {
         case 403: throw new Error('CannotAuthenticate: Bad username or password');
         case 404: throw new Error(`CannotAuthenticate: Page doesn\'t exists, make sure JWT is installed`);
@@ -58,8 +62,8 @@ export const generateToken = async (host: string, username: string, password: st
  */
 export const validateToken = async (host: string, token: string): Promise<boolean> => {
     const validateTokenEndpoint = `${host}/${CONFIG.JWT_ENDPOINT}/${CONFIG.JWT_ROUTE_VALIDATE}`;
-    const authHeader = { headers: { Authorization: 'bearer ' + token } };
-    const response = await axios.post(validateTokenEndpoint, {}, authHeader);
+    const headers = { headers: { Authorization: 'Bearer ' + token, ...CONFIG.HEADERS } };
+    const response = await axios.post(validateTokenEndpoint, {}, headers);
     if (response.status === 200) {
         return true;
     }
@@ -73,7 +77,11 @@ export const validateToken = async (host: string, token: string): Promise<boolea
  */
 export const connectToJwt = async (host: string) => {
     const generateTokenEndpoint = `${host}/${CONFIG.JWT_ENDPOINT}/${CONFIG.JWT_ROUTE_GENERATE}`;
-    const response = await axios.post(generateTokenEndpoint);
+    const response = await axios.post(generateTokenEndpoint, {}, {
+        headers: {
+            ...CONFIG.HEADERS,
+        },
+    });
     if (response.status === 404) {
         throw new Error('CannotConnect: bad host or JWT is not installed');
     }


### PR DESCRIPTION
The JWT API might be overlaid with an API key, for example, to prevent
clients from abusing the API, or a malicious third party trying to
perform a DOS attack.
The API key is usually passed through the request headers and it makes
sense to have it available for users to pass.

Signed-off-by: Adrian Oprea <adrian@oprea.rocks>